### PR TITLE
Cache stats, set activity to current sub gap + current trend

### DIFF
--- a/util.js
+++ b/util.js
@@ -2,11 +2,19 @@ const { YouTube } = require("better-youtube-api");
 const CONFIG = require("./config.json");
 const youtube = new YouTube(CONFIG.youtube.api_key);
 
+const updateListeners = [];
+const cached = {
+  "stats": {}
+}
+
 module.exports = {
-  getStats: async () => {
+  getStats: () => {
+    return cached.stats;
+  },
+  updateStats: async () => {
     const pewdiepie = await youtube.getChannel("UC-lHJZR3Gqxm24_Vd_AJ5Yw");
     const tseries = await youtube.getChannel("UCq-Fj5jknLsUf-MWSy4_brA");
-    return {
+    const newStats = {
       pewdiepie: parseInt(pewdiepie.data.statistics.subscriberCount),
       tseries: parseInt(tseries.data.statistics.subscriberCount),
       difference: parseInt(
@@ -14,5 +22,11 @@ module.exports = {
           tseries.data.statistics.subscriberCount
       ) //Javascript wonders
     };
+
+    updateListeners.forEach((listener) => listener(newStats, cached.stats));
+    return cached.stats = newStats;
+  },
+  addListener: (listener) => {
+    updateListeners.push(listener);
   }
 };


### PR DESCRIPTION
This will display the current sub gap and current trend as the current activity on discord. Can also be used to automatically send a message/tweet when it reaches X. 

![Example image](https://user-images.githubusercontent.com/5676386/52904117-9d8eb700-3227-11e9-9935-012e5f95d069.png)

Stats are refreshed every `CONFIG.youtube.refreshdelay` (ms). Should be set to something like ~`180000`. Default quota is 10 000 a day, each update uses [18 (2 x 9)](https://developers.google.com/youtube/v3/determine_quota_cost), this means 555 updates a day, once per 2.6 minutes. Might need to use a fork of better-youtube-api to minimize quota cost (only request statistics part). That will bring it down to 6 (2 x 3) quota cost per update, once per minute.