### PR TITLE
Discord : when you call a command, caps are taken into account, and space too

### DIFF
--- a/discord.js
+++ b/discord.js
@@ -180,9 +180,10 @@ client.on('ready', () => {
 client.on('message', async msg => {
 	// discord.js message event
 	try {
+		message.content = message.content.toLowerCase(); //added .toLowerCase() here 
 		if (msg.author.bot || msg.author === client.user) return // Checks if executor is bot/self
 		if (!msg.content.startsWith(CONFIG.discord.prefix)) return
-		let cmdTxt = msg.content.substr(CONFIG.discord.prefix.length)
+		let cmdTxt = msg.content.substr(CONFIG.discord.prefix.length).trim() //added .trim() here
 		let cmd = commands.find(item => {
 			// Find a command using predicate
 			return item.command === cmdTxt || item.aliases.includes(cmdTxt)


### PR DESCRIPTION
Put semi colons plz

This pull request was created by the semi colons gang 